### PR TITLE
Add task scheduling via due dates

### DIFF
--- a/task_tracker_app/app.py
+++ b/task_tracker_app/app.py
@@ -6,12 +6,22 @@ app = Flask(__name__)
 tasks = []
 task_id_counter = 1 # To generate unique task IDs
 
-def add_task(text):
-    """Adds a new task to the tasks list."""
+def add_task(text, due_date=None):
+    """Adds a new task to the tasks list.
+
+    Args:
+        text (str): The task description.
+        due_date (str, optional): Date the task is scheduled for in
+            ``YYYY-MM-DD`` format. Defaults to ``None``.
+
+    Returns:
+        dict: The task dictionary that was added.
+    """
     global task_id_counter
     new_task = {
         'id': task_id_counter,
         'text': text,
+        'due_date': due_date,
         'completed': False
     }
     tasks.append(new_task)
@@ -47,7 +57,8 @@ def index():
 def add_task_route():
     """Handles adding a new task."""
     task_text = request.form['task_text']
-    add_task(task_text)
+    due_date = request.form.get('due_date') or None
+    add_task(task_text, due_date)
     return redirect(url_for('index'))
 
 @app.route('/complete/<int:task_id>')

--- a/task_tracker_app/templates/index.html
+++ b/task_tracker_app/templates/index.html
@@ -11,6 +11,7 @@
 
     <form action="{{ url_for('add_task_route') }}" method="POST">
         <input type="text" name="task_text" placeholder="Enter a new task" required>
+        <input type="date" name="due_date">
         <button type="submit">Add Task</button>
     </form>
 
@@ -23,6 +24,9 @@
             {% else %}
                 <span class="task-text">{{ task.text }}</span>
                 <a href="{{ url_for('complete_task_route', task_id=task.id) }}" class="complete-link">Complete</a>
+            {% endif %}
+            {% if task.due_date %}
+                <span class="due-date">(Due: {{ task.due_date }})</span>
             {% endif %}
             <a href="{{ url_for('delete_task_route', task_id=task.id) }}" class="delete-link">Delete</a>
         </li>

--- a/task_tracker_app/test_app.py
+++ b/task_tracker_app/test_app.py
@@ -32,6 +32,16 @@ class TestTaskApp(unittest.TestCase):
         self.assertEqual(added_task_2['id'], 2)
         self.assertEqual(task_app_module.task_id_counter, 3)
 
+    def test_add_task_with_due_date(self):
+        """Ensure a task can be scheduled for a later date."""
+        task_text = "Task with due date"
+        due_date = "2024-12-31"
+        added_task = task_app_module.add_task(task_text, due_date)
+
+        self.assertEqual(added_task['text'], task_text)
+        self.assertEqual(added_task['due_date'], due_date)
+        self.assertEqual(task_app_module.tasks[0]['due_date'], due_date)
+
 
     def test_get_all_tasks(self):
         """Test retrieving all tasks."""


### PR DESCRIPTION
## Summary
- allow optional due date field when creating tasks
- display due dates in the list view
- test adding a task with a due date

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f4d9f8d48832cac7c74a4c9686c3e